### PR TITLE
Correção da data de atualização quando um registro for removido

### DIFF
--- a/thf-conference-api/service/LecturesService.js
+++ b/thf-conference-api/service/LecturesService.js
@@ -133,6 +133,7 @@ exports.lecturesIdDELETE = function (id) {
 
     if (lecture) {
       lecture.deletedDate = new Date().toISOString();
+      lecture.updatedDate = lecture.deletedDate;
       lecture.deleted = true;
       resolve();
     } else {


### PR DESCRIPTION
Quando uma palestra era removida a aplicação que utiliza o thf-sync não conseguia trazer esse dado atualizado, pois a data de atualização utilizada no diff não estava sendo atualizada no método DELETE.

Teste:
Usar a aplicação Web para remover uma palestra e verificar no App se ela foi removida.