### PR TITLE
Thf conference/7786

### DIFF
--- a/thf-sample-app-conference/README.md
+++ b/thf-sample-app-conference/README.md
@@ -7,7 +7,7 @@ THF Conference Application é um aplicativo de demonstração do ThfSync baseado
 
 Para saber mais sobre o ThfSync, veja em [Começando com o ThfSync](https://thf.totvs.com.br/guides/sync-get-started).
 
-As funcionalidades do ThfSync foram isoladas em serviços com exceção dos métodos que envolvem *Subscriber*. Os componentes do App concentra-se apenas na busca do serviço e nas manipulações de tela.
+As funcionalidades do ThfSync foram isoladas em serviços com exceção dos métodos que envolvem *Subscriber*. Os componentes do App concentram-se apenas na busca do serviço e nas manipulações de tela.
 
 A seguir, tem-se uma lista de funcionalidades utilizadas no App e onde podem ser encontradas.
 
@@ -89,7 +89,7 @@ A seguir, tem-se uma lista de funcionalidades utilizadas no App e onde podem ser
 ### ThfStorageService
 
 - `ThfStorageService.set()`:
-  - [src/app/app.component.ts](./app/app.component.ts#L109)
+  - [src/app/app.component.ts](./src/app/app.component.ts#L109)
   - [src/pages/signup/signup.component.ts](./src/pages/signup/signup.component.ts#L47)
 
 - `ThfStorageService.remove()`:

--- a/thf-sample-app-conference/README.md
+++ b/thf-sample-app-conference/README.md
@@ -13,29 +13,25 @@ A seguir, tem-se uma lista de funcionalidades utilizadas no App e onde podem ser
 
 ### ThfSyncService
 
-- `ThfSyncService.prepare`: src/app/app.component.ts
+- `ThfSyncService.prepare()`: [src/app/app.component.ts](./src/app/app.component.ts#L134)
 
-- `ThfSyncService.loadData`: src/app/app.component.ts
+- `ThfSyncService.loadData()`: [src/app/app.component.ts](./src/app/app.component.ts#L111)
 
-- `ThfSyncService.getResponses`: src/app/app.component.ts
+- `ThfSyncService.getResponses()`: [src/app/app.component.ts](src/app/app.component.ts#L142)
 
-- `ThfSyncService.removeItemOfSync`: src/app/app.component.ts
+- `ThfSyncService.getModel()`: src/services/*
 
-- `ThfSyncService.resumeSync`: src/app/app.component.ts
+- `ThfSyncService.insertHttpCommand()`: [src/services/user.service.ts](src/services/user.service.ts#L53)
 
-- `ThfSyncService.getModel`: src/services/*
+- `ThfSyncService.onSync()`:
+  - [src/pages/lecture-detail/lecture-detail.component.ts](./src/pages/lecture-detail/lecture-detail.component.ts#L32)
+  - [src/pages/note-list/note-list.component.ts](./src/pages/note-list/note-list.component.ts#L25)
+  - [src/pages/schedule-filter/schedule-filter.component.ts](./src/pages/schedule-filter/schedule-filter.component.ts#L22)
+  - [src/pages/schedule/schedule/component.ts](./src/pages/schedule/schedule.component.ts#L47)
+  - [src/pages/speaker-detail/speaker-detail.component.ts](./src/pages/speaker-detail/speaker-detail.component.ts#L23)
+  - [src/pages/speaker-list/speaker-list.component.ts](./src/pages/speaker-list/speaker-list.component.ts#L39)
 
-- `ThfSyncService.insertHttpCommand`: src/services/user.service.ts
-
-- `ThfSyncService.onSync`:
-  - src/pages/lecture-detail/lecture-detail.component.ts
-  - src/pages/note-list/note-list.component.ts
-  - src/pages/schedule-filter/schedule-filter.component.ts
-  - src/pages/schedule/schedule/component.ts
-  - src/pages/speaker-detail/speaker-detail.component.ts
-  - src/pages/speaker-list/speaker-list.component.ts
-
-- `ThfSyncService.sync`: 
+- `ThfSyncService.sync`:
   - src/services/lecture.service.ts
   - src/services/note.service.ts
   - src/services/speaker.service.ts

--- a/thf-sample-app-conference/README.md
+++ b/thf-sample-app-conference/README.md
@@ -20,7 +20,7 @@ A seguir, tem-se uma lista de funcionalidades utilizadas no App e onde podem ser
   - [src/app/app.component.ts](./src/app/app.component.ts#L111)
 
 - `ThfSyncService.getResponses()`:
-  - [src/app/app.component.ts](src/app/app.component.ts#L142)
+  - [src/pages/signup/signup.component.ts](./src/pages/signup/signup.component.ts#L42)
 
 - `ThfSyncService.getModel()`:
   - [src/services/conference.service.ts](./src/services/conference.service.ts#L14)

--- a/thf-sample-app-conference/README.md
+++ b/thf-sample-app-conference/README.md
@@ -13,15 +13,25 @@ A seguir, tem-se uma lista de funcionalidades utilizadas no App e onde podem ser
 
 ### ThfSyncService
 
-- `ThfSyncService.prepare()`: [src/app/app.component.ts](./src/app/app.component.ts#L134)
+- `ThfSyncService.prepare()`:
+  - [src/app/app.component.ts](./src/app/app.component.ts#L134)
 
-- `ThfSyncService.loadData()`: [src/app/app.component.ts](./src/app/app.component.ts#L111)
+- `ThfSyncService.loadData()`:
+  - [src/app/app.component.ts](./src/app/app.component.ts#L111)
 
-- `ThfSyncService.getResponses()`: [src/app/app.component.ts](src/app/app.component.ts#L142)
+- `ThfSyncService.getResponses()`:
+  - [src/app/app.component.ts](src/app/app.component.ts#L142)
 
-- `ThfSyncService.getModel()`: src/services/*
+- `ThfSyncService.getModel()`:
+  - [src/services/conference.service.ts](./src/services/conference.service.ts#L14)
+  - [src/services/lecture.service.ts](./src/services/lecture.service.ts)
+  - [src/services/note.service.ts](./src/services/note.service.ts#L12)
+  - [src/services/speaker.service.ts](./src/services/speaker.service.ts#L11)
+  - [src/services/track.service.ts](./src/services/track.service.ts#L11)
+  - [src/services/user.service.ts](./src/services/user.service.ts#L13)
 
-- `ThfSyncService.insertHttpCommand()`: [src/services/user.service.ts](src/services/user.service.ts#L53)
+- `ThfSyncService.insertHttpCommand()`:
+  - [src/services/user.service.ts](src/services/user.service.ts#L53)
 
 - `ThfSyncService.onSync()`:
   - [src/pages/lecture-detail/lecture-detail.component.ts](./src/pages/lecture-detail/lecture-detail.component.ts#L32)
@@ -31,50 +41,59 @@ A seguir, tem-se uma lista de funcionalidades utilizadas no App e onde podem ser
   - [src/pages/speaker-detail/speaker-detail.component.ts](./src/pages/speaker-detail/speaker-detail.component.ts#L23)
   - [src/pages/speaker-list/speaker-list.component.ts](./src/pages/speaker-list/speaker-list.component.ts#L39)
 
-- `ThfSyncService.sync`:
-  - src/services/lecture.service.ts
-  - src/services/note.service.ts
-  - src/services/speaker.service.ts
-  - src/services/track.service.ts
-  - src/services/user.service.ts
+- `ThfSyncService.sync()`:
+  - [src/services/lecture.service.ts](./src/services/lecture.service.ts#L24)
+  - [src/services/note.service.ts](./src/services/note.service.ts#L36)
+  - [src/services/speaker.service.ts](./src/services/speaker.service.ts#L16)
+  - [src/services/track.service.ts](./src/services/track.service.ts#L16)
+  - [src/services/user.service.ts](./src/services/user.service.ts#L104)
 
 ### ThfEntity
 
-- `ThfEntity.find`:
-  - src/services/lecture.service.ts
-  - src/services/note.service.ts
-  - src/services/speaker.service.ts
-  - src/services/track.service.ts
-  - src/services/user.service.ts
+- `ThfEntity.find()`:
+  - [src/services/lecture.service.ts](./src/services/lecture.service.ts#L20)
+  - [src/services/note.service.ts](./src/services/note.service.ts)
+  - [src/services/speaker.service.ts](./src/services/speaker.service.ts#L11)
+  - [src/services/track.service.ts](./src/services/track.service.ts#L11)
+  - [src/services/user.service.ts](./src/services/user.service.ts)
 
-- `ThfEntity.findById`:
-  - src/services/lecture.service.ts
-  - src/services/user.service.ts
-  - src/pages/speaker-detail/speaker-detail.component.ts
+- `ThfEntity.findById()`:
+  - [src/pages/speaker-detail/speaker-detail.component.ts](./src/pages/speaker-detail/speaker-detail.component.ts#L39)
+  - [src/services/lecture.service.ts](./src/services/lecture.service.ts#L16)
+  - [src/services/user.service.ts](./src/services/user.service.ts)
 
-- `ThfEntity.findOne`: src/services/conference.service.ts
+- `ThfEntity.findOne()`:
+  - [src/services/conference.service.ts](./src/services/conference.service.ts#L10)
 
-- `ThfEntity.save`:
-  - src/services/note.service.ts
-  - src/services/user.service.ts
+- `ThfEntity.save()`:
+  - [src/services/note.service.ts](./src/services/note.service.ts#L32)
+  - [src/services/user.service.ts](./src/services/user.service.ts)
 
-- `ThfEntity.remove`: src/services/note.service.ts
+- `ThfEntity.remove()`:
+  - [src/services/note.service.ts](./src/services/note.service.ts#L28)
 
 ### ThfQueryBuilder
 
-- `ThfQueryBuilder.exec`: src/services/*
+- `ThfQueryBuilder.exec()`:
+  - [src/services/conference.service.ts](./src/services/conference.service.ts#L10)
+  - [src/services/lecture.service.ts](./src/services/lecture.service.ts)
+  - [src/services/note.service.ts](./src/services/note.service.ts#L22)
+  - [src/services/speaker.service.ts](./src/services/speaker.service.ts#L11)
+  - [src/services/track.service.ts](./src/services/track.service.ts#L11)
+  - [src/services/user.service.ts](./src/services/user.service.ts)
 
-- `ThfQueryBuilder.sort`:
-  - src/services/lecture.service.ts
-  - src/services/speaker.service.ts
+- `ThfQueryBuilder.sort()`:
+  - [src/services/lecture.service.ts](./src/services/lecture.service.ts#L20)
+  - [src/services/speaker.service.ts](./src/services/speaker.service.ts#L11)
 
 ### ThfStorageService
 
-- `ThfStorageService.set`: 
-  - src/app/app.component.ts
-  - src/signup/signup.component.ts
+- `ThfStorageService.set()`:
+  - [src/app/app.component.ts](./app/app.component.ts#L109)
+  - [src/pages/signup/signup.component.ts](./src/pages/signup/signup.component.ts#L47)
 
-- `ThfStorageService.remove`: src/app/app.component.ts
+- `ThfStorageService.remove()`:
+  - [src/app/app.component.ts](./src/app/app.component.ts#L74)
 
 ### ThfSyncSchema
 

--- a/thf-sample-app-conference/src/app/app.component.ts
+++ b/thf-sample-app-conference/src/app/app.component.ts
@@ -127,7 +127,7 @@ export class MyApp {
 
   private initSync() {
     const config: ThfSyncConfig = {
-      type: ThfNetworkType.ethernet,
+      type: [ThfNetworkType.ethernet, ThfNetworkType.wifi],
       period: 10
     };
 
@@ -139,15 +139,7 @@ export class MyApp {
   }
 
   private getResponses() {
-    this.thfSync.getResponses().subscribe(thfSyncResponse => {
-
-      if (thfSyncResponse.response instanceof HttpErrorResponse) {
-        this.thfSync.removeItemOfSync(thfSyncResponse.id).then(() => {
-          this.thfSync.resumeSync();
-        });
-      }
-
-    });
+    this.thfSync.getResponses();
   }
 
   private listenToLoginEvents() {

--- a/thf-sample-app-conference/src/app/app.component.ts
+++ b/thf-sample-app-conference/src/app/app.component.ts
@@ -51,7 +51,6 @@ export class MyApp {
   ) {
 
     this.initApp();
-    this.getResponses();
   }
 
   isActive(page: PageInterface) {
@@ -136,10 +135,6 @@ export class MyApp {
 
   private isLogged() {
     this.thfStorage.get('login').then(login => this.enableMenu(!!login));
-  }
-
-  private getResponses() {
-    this.thfSync.getResponses();
   }
 
   private listenToLoginEvents() {


### PR DESCRIPTION
- Removida a implementação do método `ThfSyncService.removeItemOfSync()` que removia os itens da fila, gerando a inconsistência de quando a API estar fora, as operações realizadas no app 'se perdiam';

- Removida a documentação do método `ThfSyncService.removeItemOfSync()` do readme.md;

- Adicionado o tipo de conexão wifi no config do sync;

- Inserido links para as linhas onde as implementações dos métodos foram feitas no arquivo readme.md.